### PR TITLE
#19, #56, #21

### DIFF
--- a/src/components/ComponentPages/HistoryContainer/Collapse/campHistory.tsx
+++ b/src/components/ComponentPages/HistoryContainer/Collapse/campHistory.tsx
@@ -99,7 +99,7 @@ const CampHistory = ({ campStatement, topicNamespaceId }) => {
                 campStatement?.objector_nick_id || ""
               }?topicnum=${campStatement?.topic_num || ""}&campnum=${
                 campStatement?.camp_num || ""
-              }&namespace=1`}
+              }&namespace=${topicNamespaceId || ""}`}
               passHref
             >
               <a>{campStatement?.objector_nick_name}</a>

--- a/src/components/ComponentPages/ResetPassword/__test__/resetPassword.test.tsx
+++ b/src/components/ComponentPages/ResetPassword/__test__/resetPassword.test.tsx
@@ -15,7 +15,7 @@ const { placeholders, labels, validations } = messages;
 describe("Reset Password page", () => {
   it("render heading labels and text", async () => {
     render(<ResetPassword is_test={true} />);
-    let heading = screen.getByText("Create new password");
+    let heading = screen.getByText(labels.createPassword);
     expect(heading).toBeInTheDocument();
     expect(screen.getByText(labels.newPassword)).toBeInTheDocument();
     expect(screen.getByText(labels.confirmPassword)).toBeInTheDocument();

--- a/src/components/ComponentPages/Statement/AddOrManage/index.tsx
+++ b/src/components/ComponentPages/Statement/AddOrManage/index.tsx
@@ -64,6 +64,9 @@ export default function AddOrManage({ add }) {
   const [editStatementData, setEditStatementData] = useState({ data: null });
   const [submitIsDisable, setSubmitIsDisable] = useState(true);
   const [submitIsDisableCheck, setSubmitIsDisableCheck] = useState(true);
+  const [currentTopicData, setCurrentTopicData] = useState({
+    namespace_id: "",
+  });
 
   const [modalVisible, setModalVisible] = useState(false);
   const [nickNameData, setNickNameData] = useState([]);
@@ -307,6 +310,8 @@ export default function AddOrManage({ add }) {
           topic_num: router?.query?.statement[0].split("-")[0],
           camp_num: router?.query?.statement[1].split("-")[0] ?? "1",
         });
+        setCurrentTopicData(topic_res);
+        console.log("topic_res", topic_res);
         setPayloadBreadCrumb({
           camp_num: router?.query?.statement[1].split("-")[0] ?? "1",
           topic_num: router?.query?.statement[0].split("-")[0],
@@ -1086,8 +1091,8 @@ export default function AddOrManage({ add }) {
               </Descriptions.Item>
 
               <Descriptions.Item label="Camp About URL">
-                <Link href={form?.getFieldValue("camp_about_url")}>
-                  <a>{form?.getFieldValue("camp_about_url")}</a>
+                <Link href={form?.getFieldValue("camp_about_url") || ""}>
+                  <a>{form?.getFieldValue("camp_about_url") || ""}</a>
                 </Link>
               </Descriptions.Item>
 
@@ -1135,7 +1140,11 @@ export default function AddOrManage({ add }) {
                 editStatementData?.data?.topic?.camp_num ||
                 router?.query?.statement?.at(1)?.split("-")[0] ||
                 1
-              }&namespace=${editStatementData?.data?.topic?.namespace_id || 1}`}
+              }&namespace=${
+                editStatementData?.data?.topic?.namespace_id ||
+                currentTopicData?.namespace_id ||
+                ""
+              }`}
               passHref
             >
               <a>

--- a/src/components/ComponentPages/TopicDetails/SupportTreeCard/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/SupportTreeCard/index.tsx
@@ -60,11 +60,11 @@ const SupportTreeCard = ({
   handleSupportTreeCardCancel,
   removeSupportSpinner,
 }) => {
-  const { currentGetCheckSupportExistsData,is_checked } = useSelector(
+  const { currentGetCheckSupportExistsData, is_checked } = useSelector(
     (state: RootState) => ({
       currentGetCheckSupportExistsData:
         state.topicDetails.currentGetCheckSupportExistsData,
-        is_checked: state?.utils?.score_checkbox,
+      is_checked: state?.utils?.score_checkbox,
     })
   );
   const { isUserAuthenticated } = isAuth();
@@ -178,7 +178,7 @@ const SupportTreeCard = ({
                         {is_checked && isUserAuthenticated
                           ? data[item].full_score?.toFixed(2)
                           : data[item].score?.toFixed(2)}
-                          {/* {data[item].score?.toFixed(2)} */}
+                        {/* {data[item].score?.toFixed(2)} */}
                       </span>
                       {isUserAuthenticated ? (
                         !userNickNameList.includes(data[item].nick_name_id) ? (
@@ -269,10 +269,9 @@ const SupportTreeCard = ({
           <Paragraph>
             Total Support for This Camp (including sub-camps):
             <span className="number-style">
-            {is_checked && isUserAuthenticated
-                          ? totalFullSupportScore?.toFixed(2)
-                          : totalSupportScore?.toFixed(2)}
-                          
+              {is_checked && isUserAuthenticated
+                ? totalFullSupportScore?.toFixed(2)
+                : totalSupportScore?.toFixed(2)}
             </span>
           </Paragraph>
 


### PR DESCRIPTION
1. #19 Objector Nickname links from Topic /camp/statement history pages should redirect to a specific namespace list(where the current topic is created)
2. #56 Nickname links from Add camp statement preview pop-up should redirect to a specific namespace list(where the current topic is created)
3. #21 Page breaks on clicking on the preview for the following case in camp update