### PR TITLE
Ticket #125

### DIFF
--- a/src/components/ComponentPages/HistoryContainer/index.tsx
+++ b/src/components/ComponentPages/HistoryContainer/index.tsx
@@ -122,7 +122,9 @@ function HistoryContainer() {
   }, [tree]);
 
   useEffect(() => {
+    if(isUserAuthenticated){
     setCampHistory(history);
+    }
   }, [history]);
 
   useEffect(() => {


### PR DESCRIPTION
When a direct supporter copies the URL and logs in, the Object button is disabled; however, when the page is reloaded, the Object button is enabled.