### PR TITLE
Ticket #125

### DIFF
--- a/src/components/ComponentPages/HistoryContainer/index.tsx
+++ b/src/components/ComponentPages/HistoryContainer/index.tsx
@@ -156,18 +156,19 @@ function HistoryContainer() {
         per_page: 4,
         page: count.current,
       };
+      if (isUserAuthenticated) {
+        let res = await getHistoryApi(reqBody, count.current, historyOf);
 
-      let res = await getHistoryApi(reqBody, count.current, historyOf);
-
-      if (!res || !res?.last_page) {
-        setLoadMoreItems(false);
-        setLoadingIndicator(false);
-        return;
-      }
-      if (count.current >= res?.last_page) {
-        setLoadMoreItems(false);
-      } else {
-        count.current = count.current + 1;
+        if (!res || !res?.last_page) {
+          setLoadMoreItems(false);
+          setLoadingIndicator(false);
+          return;
+        }
+        if (count.current >= res?.last_page) {
+          setLoadMoreItems(false);
+        } else {
+          count.current = count.current + 1;
+        }
       }
       setLoadingIndicator(false);
     } catch (error) {}


### PR DESCRIPTION
When a direct supporter copies the URL and logs in, the Object button is disabled; however, when the page is reloaded, the Object button is enabled.