### PR TITLE
Ticket #367 #366 #369 #323

### DIFF
--- a/src/components/ComponentPages/ArchivedCampCheckBox/index.tsx
+++ b/src/components/ComponentPages/ArchivedCampCheckBox/index.tsx
@@ -25,7 +25,7 @@ const ArchivedCampCheckBox = () => {
   );
 
   const setCheckboxStore = (val) => {
-    dispatch(setArchivedCheckBox(val)), console.log(val, "val");
+    dispatch(setArchivedCheckBox(val));
   };
 
   const onChange = (e: CheckboxChangeEvent) => {

--- a/src/components/ComponentPages/Home/TopicsList/index.tsx
+++ b/src/components/ComponentPages/Home/TopicsList/index.tsx
@@ -79,12 +79,15 @@ const TopicsList = () => {
     is_checked: state?.utils?.score_checkbox,
     is_archive: state?.filters?.filterObject?.is_archive,
   }));
+  const { is_camp_archive_checked } = useSelector((state: RootState) => ({
+    is_camp_archive_checked: state?.utils?.archived_checkbox,
+  }));
   const [topicsData, setTopicsData] = useState(canonizedTopics);
   const [nameSpacesList, setNameSpacesList] = useState(nameSpaces);
 
   const [isReview, setIsReview] = useState(asof == "review");
-  const [inputSearch, setInputSearch] = useState(search || "");
-  const [archiveSearch, setArchiveSearch] = useState(0);
+  const [inputSearch, setInputSearch] = useState(search||"");
+  // const [archiveSearch, setArchiveSearch] = useState(is_archive || 0);
 
   const [nameSpaceId, setNameSpaceId] = useState(filterNameSpaceId || "");
 
@@ -133,7 +136,14 @@ const TopicsList = () => {
       })
     );
   };
-
+  // const checkTopics = (topics)=>{
+  //   let archive = 
+  //   if(topics?.length > 0 && !is_camp_archive_checked){
+  //     topics?.forEach(element => {
+  //       if(element.item.is_archive)
+  //     });
+  //   }
+  // }
   useEffect(() => {
     if (filterNameSpace?.toLowerCase() !== "/general/") {
       router.query.canon = formatnamespace(filterNameSpace);
@@ -165,7 +175,7 @@ const TopicsList = () => {
   useEffect(() => {
     setSelectedNameSpace(filterNameSpace);
     setNameSpaceId(filterNameSpaceId);
-    setArchiveSearch(is_archive);
+    // setArchiveSearch(is_archive);
     setInputSearch(search.trim());
     setNameSpacesList(nameSpaces);
   }, [filterNameSpace, filterNameSpaceId, search, nameSpaces, is_archive]);
@@ -195,6 +205,7 @@ const TopicsList = () => {
     filterByScore,
     inputSearch,
     onlyMyTopicsCheck.current,
+    is_camp_archive_checked
   ]);
   useEffect(() => {
     if (inputSearch.length > 0 || search.length > 0) {
@@ -224,7 +235,7 @@ const TopicsList = () => {
       filter: filterByScore,
       asof: asof,
       user_email: onlyMyTopicsCheck.current ? userEmail : "",
-      is_archive: archiveSearch,
+      is_archive: is_camp_archive_checked ? 1: 0,
     };
     await getCanonizedTopicsApi(reqBody, loadMore);
     setLoadMoreIndicator(false);
@@ -401,6 +412,7 @@ const TopicsList = () => {
                       )}/1-Agreement`,
                     }}
                   >
+                    {!item.is_archive || (item.is_archive  && is_camp_archive_checked) ?
                     <a
                       onClick={() => {
                         handleTopicClick();
@@ -418,7 +430,7 @@ const TopicsList = () => {
                           ? item?.topic_full_score?.toFixed(2)
                           : item?.topic_score?.toFixed(2)}
                       </Tag>
-                    </a>
+                    </a>: <></>}
                   </Link>
                 </>
               </List.Item>

--- a/src/components/ComponentPages/TopicDetails/CampTree/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/CampTree/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Tree, Tooltip, Select, Image } from "antd";
+import { Tree, Tooltip, Select, Image, Popover } from "antd";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../../../../store";
 import Link from "next/link";
@@ -280,19 +280,25 @@ const CampTree = ({
                         >
                           <a
                             className={
+                             data[item].is_archive == 1 ? `font-weight-bold ${styles.archive_grey}`:
                               data[item]?.camp_id ==
                                 router?.query?.camp?.at(1)?.split("-")?.at(0) ??
-                              "1"
-                                ? `font-weight-bold ${styles.activeCamp}`
+                              "1" 
+                                ? `font-weight-bold ${styles.activeCamp}` 
                                 : ""
                             }
                           >
+                            {data[item].is_archive == 1 ?
+                            <Popover  content="Archived Camp">
                             {includeReview
                               ? data[item]?.review_title
                               : data[item]?.title}
+                              </Popover>:includeReview
+                              ? data[item]?.review_title
+                              : data[item]?.title }
                           </a>
                         </Link>{" "}
-                        {data[item].is_archive == 1 ? (
+                        {/* {data[item].is_archive == 1 ? (
                           <Image
                             src={Archive_icon.src}
                             width={20}
@@ -302,7 +308,7 @@ const CampTree = ({
                           />
                         ) : (
                           ""
-                        )}
+                        )} */}
                       </span>
                       <span className={styles.subScriptionIcon}>
                         {isUserAuthenticated &&

--- a/src/components/ComponentPages/TopicDetails/topicDetails.module.scss
+++ b/src/components/ComponentPages/TopicDetails/topicDetails.module.scss
@@ -288,3 +288,7 @@
     width: 15px;
   }
 }
+
+.archive_grey{
+  color: #6A6A6A !important;
+}


### PR DESCRIPTION
Call API on browse page on "Show archived camps" checked/unchecked Implement show hide archive in Browse page
Implement new design for archived camps on topic detail page It allows any user to search the Archived Camps/Topics without selecting the checkbox "Show archived camps".