### PR TITLE
Ticket #396

### DIFF
--- a/src/components/ComponentPages/Statement/AddOrManage/index.tsx
+++ b/src/components/ComponentPages/Statement/AddOrManage/index.tsx
@@ -516,7 +516,7 @@ export default function AddOrManage({ add }: any) {
       } else {
         op.checked = false;
       }
-      op.tooltip = op.checked ? "Unarchive the camp." : "Archive the camp.";
+       op.tooltip = op.id === "is_archive"?op.checked ? "Unarchive the camp." : "Archive the camp.":op.tooltip;
     });
     setOptions(oldOptions);
     if (


### PR DESCRIPTION
While creating and updating the camps, it shows "Archive the camp" and "Unarchive the camp" tool-tips over the "Disable additional sub camps" and "Single level sub camps only".