### PR TITLE
Ticket #485

### DIFF
--- a/src/components/ComponentPages/HistoryContainer/Collapse/index.tsx
+++ b/src/components/ComponentPages/HistoryContainer/Collapse/index.tsx
@@ -412,8 +412,8 @@ function HistoryCollapse({
                     id={`submit-update-${campStatement?.id}`}
                     className={`mr-3 ${styles.campUpdateButton}`}
                     onClick={() =>
-                      campHistoryItems[0]?.is_archive == 1 &&
-                      campHistoryItems[0]?.status == "live"
+                      campStatement?.is_archive == 1 &&
+                      campStatement?.status == "live"
                         ? callManageCampApi()
                         : submitUpdateRedirect(historyOf)
                     }


### PR DESCRIPTION
When a user clicks Unarchive this camp, it redirects to the camp update page rather than creating a new record on the history page.