### PR TITLE
Hot fix  #658 #882

### DIFF
--- a/src/components/ComponentPages/searchCanonizer/index.tsx
+++ b/src/components/ComponentPages/searchCanonizer/index.tsx
@@ -224,7 +224,7 @@ const Search = () => {
                             <span className={styles.ml_auto}>
                               Supported camps:{" "}
                               <strong className={styles.yellow_color}>
-                                {x.support_count}
+                                {x.support_count == "" ? 0 : x.support_count}
                               </strong>{" "}
                             </span>
                           </li>

--- a/src/components/ComponentPages/searchCanonizer/nickname.tsx
+++ b/src/components/ComponentPages/searchCanonizer/nickname.tsx
@@ -72,7 +72,7 @@ const NicknameSearch = () => {
                             <span className={styles.ml_auto}>
                               Supported camps:{" "}
                               <strong className={styles.yellow_color}>
-                                {x.support_count ? x.support_count : 0}
+                                {x.support_count == "" ? 0 : x.support_count}
                               </strong>{" "}
                             </span>
                           </li>

--- a/src/components/ComponentPages/searchCanonizer/topic.tsx
+++ b/src/components/ComponentPages/searchCanonizer/topic.tsx
@@ -66,7 +66,7 @@ const TopicSearch = () => {
                           <li>
                             <Link href={`/${x?.link}`}>
                               <a>
-                                <label>{x?.type_value}</label>
+                                <label  style={{ cursor: "pointer" }}>{x?.type_value}</label>
                               </a>
                             </Link>
 

--- a/src/components/common/headers/HeaderMenu/index.tsx
+++ b/src/components/common/headers/HeaderMenu/index.tsx
@@ -351,7 +351,7 @@ const HeaderMenu = ({ loggedUser }: any) => {
                           <span className="ml_auto suppport_camps">
                             Supported camps:{" "}
                             <strong className={styles.yellow_color}>
-                              {x.support_count}
+                              {x.support_count == ""? 0 :x.support_count}
                             </strong>{" "}
                           </span>
                         </div>
@@ -573,7 +573,7 @@ const HeaderMenu = ({ loggedUser }: any) => {
         </ul>
       </nav>
 
-      <div className="search_header">
+      {!process.env.NEXT_PUBLIC_NEW_SEARCH_BAR?<div className="search_header">
         <AutoComplete
           popupClassName="certain-category-search-dropdown"
           dropdownMatchSelectWidth={false}
@@ -625,7 +625,7 @@ const HeaderMenu = ({ loggedUser }: any) => {
             />
           </div>
         </AutoComplete>
-      </div>
+      </div>:""}
     </Fragment>
   );
 };


### PR DESCRIPTION
Global Search - when a nick name is not supporting any camps, it should display 0 instead of blank 
Hide advance search design on production