### PR TITLE
Ticket #810 #1670

### DIFF
--- a/src/components/ComponentPages/ManageSupport/ManageSupportUI/index.tsx
+++ b/src/components/ComponentPages/ManageSupport/ManageSupportUI/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Card, Tag, Select, Button, Col, Form } from "antd";
 import { DraggableArea } from "react-draggable-tags";
 import { CloseCircleOutlined } from "@ant-design/icons";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useRouter } from "next/router";
 
 import styles from "../ManageSupportUI/ManageSupport.module.scss";
@@ -14,6 +14,7 @@ import { addSupport, removeSupportedCamps } from "src/network/api/userApi";
 import CustomSkelton from "src/components/common/customSkelton";
 import SupportRemovedModal from "src/components/common/supportRemovedModal";
 import My404 from "../../404";
+import { setIsSupportModal } from "src/store/slices/topicSlice";
 
 const { placeholders } = messages;
 
@@ -55,7 +56,7 @@ const ManageSupportUI = ({
     }));
 
   const router = useRouter();
-
+const dispatch = useDispatch()
   const [removeForm] = Form.useForm();
   // const openPopup = () => setIsSupportTreeCardModal(true);
   const closePopup = () => {};
@@ -446,6 +447,7 @@ const ManageSupportUI = ({
                           onClick={(e) => {
                             e.preventDefault();
                             window.location.href = tag.link;
+                            dispatch(setIsSupportModal(false))
                           }}
                         >
                           {tag?.camp_name}

--- a/src/components/common/headers/loggedInHeader/index.tsx
+++ b/src/components/common/headers/loggedInHeader/index.tsx
@@ -21,7 +21,7 @@ const LoggedInHeader = () => {
       ) : (
         <></>
       )}
-      <SearchSection />
+      {/* <SearchSection /> */}
       <div className="topicMobBTN">
         <TopicCreationBTN key="create-topic-area" />
       </div>

--- a/src/components/common/headers/loggedOutHeader/index.tsx
+++ b/src/components/common/headers/loggedOutHeader/index.tsx
@@ -119,7 +119,7 @@ const LoggedOutHeader = () => {
       ) : (
         <></>
       )}
-      <SearchSection />
+      {/* <SearchSection /> */}
       <div className="topicMobBTN">
         <TopicCreationBTN key="create-topic-area" />
       </div>

--- a/src/components/common/searchSection/__test__/index.test.tsx
+++ b/src/components/common/searchSection/__test__/index.test.tsx
@@ -95,7 +95,7 @@ describe("Camp statement on camp details page", () => {
             pathname: "/topic/88-Mind-and-Consciousness-revie/1-Agreement",
           })}
         >
-          <SearchSection />
+          {/* <SearchSection /> */}
         </RouterContext.Provider>
       </Provider>
     );


### PR DESCRIPTION
When a user clicks on the camp name, the support pop-up should close. Remove old search option from frontend from all pages