### PR TITLE
iffort-#840

### DIFF
--- a/src/components/ComponentPages/UserProfile/UserProfileUI/index.tsx
+++ b/src/components/ComponentPages/UserProfile/UserProfileUI/index.tsx
@@ -84,7 +84,7 @@ const UserProfile = () => {
     const userId = router?.query?.supports?.[0];
     const namespace_name_id = dropdownNameSpaceList
       ? dropdownNameSpaceList
-      : router?.query?.canon;
+      : (router?.query?.canon ?? router?.query?.namespace);
     // if (dropdownNameSpaceList) {
     const query = `${userId}?namespace=${namespace_name_id}`;
     UserSupportedCampsListApi(query);


### PR DESCRIPTION
#840: get namespace_id from namespace when canon is not present in url