### PR TITLE
Ticket #1416 #1449

### DIFF
--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -1032,6 +1032,11 @@ body {
   }
 }
 
+.titleDiv {
+  width: 100%;
+}
+ 
+
 // a{
 //   @apply text-canBlue;
 // }

--- a/src/components/ComponentPages/TopicDetails/CampTree/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/CampTree/index.tsx
@@ -377,7 +377,7 @@ const CampTree = ({
                       className={
                         "treeListItemTitle " +
                         styles.treeListItemTitle +
-                        " !text-sm !text-canBlack font-normal hover:!text-canblack"
+                        ` !text-sm !text-canBlack font-normal hover:!text-canblack ${uniqueKeys.includes(data[item].camp_id.toString()) ? "!font-bold" : ""}`
                       }
                     >
                       <Link

--- a/src/components/common/SearchSideBar/index.tsx
+++ b/src/components/common/SearchSideBar/index.tsx
@@ -47,6 +47,11 @@ export default function SearchSideBar() {
     selectedStatementFromAdvanceFilterAlgorithm:
       state?.searchSlice?.selectedStatementFromAdvanceFilterAlgorithm,
   }));
+  const campTotal = searchValue === ""
+  ? searchMetaData?.camp_total
+  : (router.query.asof === "review" || router.query.asof === "bydate")
+  ? selectedCampFromAdvanceFilterAlgorithm?.length
+  : searchCountForMetaData?.camp_total;
   return (
     <>
       <div className="leftSideBar_Card noFilter">
@@ -151,14 +156,7 @@ export default function SearchSideBar() {
                     Camp{" "}
                     <span>
                       {" "}
-                      &nbsp;(
-                      {searchValue == ""
-                        ? searchMetaData?.camp_total
-                        : router.query.asof == "review" ||
-                          router.query.asof == "bydate"
-                        ? selectedCampFromAdvanceFilterAlgorithm?.length
-                        : searchCountForMetaData?.camp_total}
-                      )
+                      &nbsp;({campTotal})
                     </span>
                   </a>
                 </Button>

--- a/src/components/common/SearchSideBar/index.tsx
+++ b/src/components/common/SearchSideBar/index.tsx
@@ -156,7 +156,7 @@ export default function SearchSideBar() {
                         ? searchMetaData?.camp_total
                         : router.query.asof == "review" ||
                           router.query.asof == "bydate"
-                        ? selectedCampFromAdvanceFilterAlgorithm.length
+                        ? selectedCampFromAdvanceFilterAlgorithm?.length
                         : searchCountForMetaData?.camp_total}
                       )
                     </span>

--- a/src/components/common/customSkelton/style.module.scss
+++ b/src/components/common/customSkelton/style.module.scss
@@ -331,5 +331,5 @@
 }
 .search_skeleton{
   display: block;
+  width: 100%;
 }
-


### PR DESCRIPTION
Functionality "Collapse camps with support less than" is not working Camp Result Search - Page is crashed when "Search Include review" filter is selected from "Advance Filters"