### PR TITLE
fixed issue 1218

### DIFF
--- a/src/components/ComponentPages/HistoryContainer/Collapse/campHistory.tsx
+++ b/src/components/ComponentPages/HistoryContainer/Collapse/campHistory.tsx
@@ -101,11 +101,11 @@ const CampHistory = ({ campStatement, topicNamespaceId }: any) => {
           Parent Camp :<span>{campStatement?.parent_camp_name}</span>
         </p>
       )}
-      {campStatement?.key_words && (
+      {/* {campStatement?.key_words && (
         <p>
           Keywords :<span>{campStatement?.key_words}</span>
         </p>
-      )}
+      )} */}
       {campStatement?.object_reason && (
         <p>
           Object Reason : <span>{campStatement?.object_reason}</span>

--- a/src/components/ComponentPages/HistoryContainer/Collapse/historyComparison.tsx
+++ b/src/components/ComponentPages/HistoryContainer/Collapse/historyComparison.tsx
@@ -73,11 +73,11 @@ const HistoryComparison = ({
                 Parent Camp :<span>{campStatement?.parent_camp_name}</span>
               </p>
             )}
-            {campStatement?.key_words && (
+            {/* {campStatement?.key_words && (
               <p>
                 Keywords: <span>{campStatement?.key_words}</span>
               </p>
-            )}
+            )} */}
             <p className="break-all">
               Edit summary: <span>{campStatement?.note}</span>
             </p>


### PR DESCRIPTION
remove the keywords field for new and old camps on the camp history and comparison page