### PR TITLE
Fix the NaN issue if the score is o in terms of percentage.

### DIFF
--- a/src/components/ComponentPages/Home/TrandingTopic/scoreTag.tsx
+++ b/src/components/ComponentPages/Home/TrandingTopic/scoreTag.tsx
@@ -16,9 +16,11 @@ const ScoreTag = ({ topic_score, hideRank = false,isPercentage = false }) => {
     );
   };
 
+  const isValidScore = typeof topic_score === "number" && !isNaN(topic_score);
+
   return (
     <>
-      {topic_score == undefined || hideRank ? (
+      {!isValidScore || hideRank ? (
         <Popover
           placement={"topLeft"}
           content={popoverContent}


### PR DESCRIPTION
This fix is related to the issue  #1776. Now the score is blur instead of NaN.