### PR TITLE
fix(a11y): enable Enter key navigation for Add News menu item

### DIFF
--- a/src/components/ComponentPages/TopicDetails/CampInfoBar/InfoBar/__test__/index.test.tsx
+++ b/src/components/ComponentPages/TopicDetails/CampInfoBar/InfoBar/__test__/index.test.tsx
@@ -184,4 +184,80 @@ describe("Camp statement on camp details page", () => {
       })
     ).toBeInTheDocument();
   });
+
+  it("Should navigate to add news page when Add News menu item is clicked", async () => {
+    const mockRouter = createMockRouter({
+      pathname: "/topic/88-Mind-and-Consciousness-revie/1-Agreement",
+      asPath: "/topic/88-Mind-and-Consciousness-revie/1-Agreement",
+      query: {
+        camp: ["88-Mind-and-Consciousness-revie", "1-Agreement"],
+      },
+    });
+
+    render(
+      <Provider store={store1}>
+        <RouterContext.Provider value={mockRouter}>
+          <InfoBar payload={payload} isTopicPage={true} />
+        </RouterContext.Provider>
+      </Provider>
+    );
+
+    // Open the dropdown menu
+    const dropdownTrigger = document.querySelector(
+      ".ant-dropdown-trigger.iconMore.campForumDropdown"
+    );
+    fireEvent.click(dropdownTrigger);
+
+    // Find and click the Add News menu item
+    const addNewsMenuItem = screen.getByRole("menuitem", {
+      name: /add news/i,
+    });
+    expect(addNewsMenuItem).toBeInTheDocument();
+
+    fireEvent.click(addNewsMenuItem);
+
+    // Verify router.push was called with the correct path
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        "/addnews/88-Mind-and-Consciousness-revie/1-Agreement"
+      );
+    });
+  });
+
+  it("Should navigate to add news page from support page", async () => {
+    const mockRouter = createMockRouter({
+      pathname: "/support/[...manageSupport]",
+      asPath: "/support/88-Mind-and-Consciousness-revie/1-Agreement",
+      query: {
+        manageSupport: ["88-Mind-and-Consciousness-revie", "1-Agreement"],
+      },
+    });
+
+    render(
+      <Provider store={store1}>
+        <RouterContext.Provider value={mockRouter}>
+          <InfoBar payload={payload} isTopicPage={true} />
+        </RouterContext.Provider>
+      </Provider>
+    );
+
+    // Open the dropdown menu
+    const dropdownTrigger = document.querySelector(
+      ".ant-dropdown-trigger.iconMore.campForumDropdown"
+    );
+    fireEvent.click(dropdownTrigger);
+
+    // Find and click the Add News menu item
+    const addNewsMenuItem = screen.getByRole("menuitem", {
+      name: /add news/i,
+    });
+    fireEvent.click(addNewsMenuItem);
+
+    // Verify router.push was called with the correct path (replacing support with addnews)
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        "/addnews/88-Mind-and-Consciousness-revie/1-Agreement"
+      );
+    });
+  });
 });

--- a/src/components/ComponentPages/TopicDetails/CampInfoBar/infoBar.tsx
+++ b/src/components/ComponentPages/TopicDetails/CampInfoBar/infoBar.tsx
@@ -217,16 +217,18 @@ const InfoBar = ({
         )}
       </Menu.Item>
       {isUserAuthenticated && is_admin && (
-        <Menu.Item key="0" icon={<i className="icon-newspaper"></i>}>
-          {router?.pathname == "/support/[...manageSupport]" ? (
-            <Link href={router?.asPath.replace("support", "addnews")}>
-              Add News
-            </Link>
-          ) : (
-            <Link href={router?.asPath.replace("topic", "addnews")}>
-              Add News
-            </Link>
-          )}
+        <Menu.Item
+          key="0"
+          icon={<i className="icon-newspaper"></i>}
+          onClick={() => {
+            const path =
+              router?.pathname == "/support/[...manageSupport]"
+                ? router?.asPath.replace("support", "addnews")
+                : router?.asPath.replace("topic", "addnews");
+            router?.push(path);
+          }}
+        >
+          Add News
         </Menu.Item>
       )}
       <Menu.Item
@@ -564,7 +566,10 @@ const InfoBar = ({
                       >
                         <a
                           className={styles.iconMore}
-                          onClick={(e) => {e.preventDefault(); dispatch(setManageSupportStatusCheck(false))}}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            dispatch(setManageSupportStatusCheck(false));
+                          }}
                         >
                           <MoreOutlined />
                         </a>


### PR DESCRIPTION
## Summary

This PR fixes the keyboard navigation issue where pressing Enter on the "Add News" menu item in the three-dot dropdown menu did not trigger navigation.

### Problem
- The nested `<Link>` component inside `<Menu.Item>` caused keyboard events (Enter key) to not properly trigger navigation
- Users relying on keyboard navigation could not access the "Add News" functionality

### Solution
- Replace nested `<Link>` with `onClick` handler using `router.push()`
- This ensures both click and Enter key events trigger navigation correctly

## Changes

| File | Change |
|------|--------|
| `src/components/ComponentPages/TopicDetails/CampInfoBar/infoBar.tsx` | Replace nested Link with onClick |
| `src/components/ComponentPages/TopicDetails/CampInfoBar/InfoBar/__test__/index.test.tsx` | Add 2 test cases |

## Test Plan

- [x] Unit tests pass (3/3)
- [x] Format check passes
- [ ] Manual testing: Navigate with keyboard (Tab + Enter) to Add News

### Test Cases Added
1. `Should navigate to add news page when Add News menu item is clicked`
2. `Should navigate to add news page from support page`

### How to Verify Manually
1. Login as admin
2. Navigate to any Topic page
3. Press Tab to focus on the three-dot menu (...)
4. Press Enter to open the dropdown
5. Use arrow keys to navigate to "Add News"
6. Press Enter - should navigate to Add News page

## Accessibility Impact

| Before | After |
|--------|-------|
| ❌ Enter key does not work | ✅ Enter key triggers navigation |
| ❌ Keyboard-only users blocked | ✅ Full keyboard accessibility |

## AI Disclosure

This PR was developed with assistance from **Claude** (Anthropic).
AI was used for: code analysis, implementation, test writing, and documentation.

---

Closes #2162