### PR TITLE
fix(ux): add page loading indicator for route transitions

### DIFF
--- a/src/components/common/PageLoadingIndicator/PageLoadingIndicator.module.scss
+++ b/src/components/common/PageLoadingIndicator/PageLoadingIndicator.module.scss
@@ -1,0 +1,12 @@
+.pageLoadingOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.8);
+  z-index: 9999;
+}

--- a/src/components/common/PageLoadingIndicator/__test__/PageLoadingIndicator.test.tsx
+++ b/src/components/common/PageLoadingIndicator/__test__/PageLoadingIndicator.test.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import { NextRouter } from "next/router";
+
+import PageLoadingIndicator from "../";
+
+// Mock router with event emitter functionality
+function createMockRouter(): NextRouter & {
+  triggerRouteChangeStart: () => void;
+  triggerRouteChangeComplete: () => void;
+  triggerRouteChangeError: () => void;
+} {
+  const eventHandlers: { [key: string]: Function[] } = {};
+
+  const router = {
+    basePath: "",
+    pathname: "/",
+    route: "/",
+    query: {},
+    asPath: "/",
+    back: jest.fn(),
+    beforePopState: jest.fn(),
+    prefetch: jest.fn(),
+    push: jest.fn(),
+    reload: jest.fn(),
+    replace: jest.fn(),
+    events: {
+      on: jest.fn((event: string, handler: Function) => {
+        if (!eventHandlers[event]) {
+          eventHandlers[event] = [];
+        }
+        eventHandlers[event].push(handler);
+      }),
+      off: jest.fn((event: string, handler: Function) => {
+        if (eventHandlers[event]) {
+          eventHandlers[event] = eventHandlers[event].filter(
+            (h) => h !== handler
+          );
+        }
+      }),
+      emit: jest.fn(),
+    },
+    isFallback: false,
+    isLocaleDomain: false,
+    isReady: true,
+    defaultLocale: "en",
+    domainLocales: [],
+    isPreview: false,
+    triggerRouteChangeStart: () => {
+      eventHandlers["routeChangeStart"]?.forEach((handler) => handler("/test"));
+    },
+    triggerRouteChangeComplete: () => {
+      eventHandlers["routeChangeComplete"]?.forEach((handler) =>
+        handler("/test")
+      );
+    },
+    triggerRouteChangeError: () => {
+      eventHandlers["routeChangeError"]?.forEach((handler) =>
+        handler(new Error("Route error"), "/test")
+      );
+    },
+  } as NextRouter & {
+    triggerRouteChangeStart: () => void;
+    triggerRouteChangeComplete: () => void;
+    triggerRouteChangeError: () => void;
+  };
+
+  return router;
+}
+
+afterEach(cleanup);
+
+describe("PageLoadingIndicator", () => {
+  it("should not render when not loading", () => {
+    const mockRouter = createMockRouter();
+
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <PageLoadingIndicator />
+      </RouterContext.Provider>
+    );
+
+    expect(
+      screen.queryByTestId("page-loading-indicator")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render loading indicator when route change starts", () => {
+    const mockRouter = createMockRouter();
+
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <PageLoadingIndicator />
+      </RouterContext.Provider>
+    );
+
+    act(() => {
+      mockRouter.triggerRouteChangeStart();
+    });
+
+    expect(screen.getByTestId("page-loading-indicator")).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("should hide loading indicator when route change completes", () => {
+    const mockRouter = createMockRouter();
+
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <PageLoadingIndicator />
+      </RouterContext.Provider>
+    );
+
+    act(() => {
+      mockRouter.triggerRouteChangeStart();
+    });
+
+    expect(screen.getByTestId("page-loading-indicator")).toBeInTheDocument();
+
+    act(() => {
+      mockRouter.triggerRouteChangeComplete();
+    });
+
+    expect(
+      screen.queryByTestId("page-loading-indicator")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should hide loading indicator when route change errors", () => {
+    const mockRouter = createMockRouter();
+
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <PageLoadingIndicator />
+      </RouterContext.Provider>
+    );
+
+    act(() => {
+      mockRouter.triggerRouteChangeStart();
+    });
+
+    expect(screen.getByTestId("page-loading-indicator")).toBeInTheDocument();
+
+    act(() => {
+      mockRouter.triggerRouteChangeError();
+    });
+
+    expect(
+      screen.queryByTestId("page-loading-indicator")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should register and unregister event listeners", () => {
+    const mockRouter = createMockRouter();
+
+    const { unmount } = render(
+      <RouterContext.Provider value={mockRouter}>
+        <PageLoadingIndicator />
+      </RouterContext.Provider>
+    );
+
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      "routeChangeStart",
+      expect.any(Function)
+    );
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      "routeChangeComplete",
+      expect.any(Function)
+    );
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      "routeChangeError",
+      expect.any(Function)
+    );
+
+    unmount();
+
+    expect(mockRouter.events.off).toHaveBeenCalledWith(
+      "routeChangeStart",
+      expect.any(Function)
+    );
+    expect(mockRouter.events.off).toHaveBeenCalledWith(
+      "routeChangeComplete",
+      expect.any(Function)
+    );
+    expect(mockRouter.events.off).toHaveBeenCalledWith(
+      "routeChangeError",
+      expect.any(Function)
+    );
+  });
+});

--- a/src/components/common/PageLoadingIndicator/index.tsx
+++ b/src/components/common/PageLoadingIndicator/index.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { Spin } from "antd";
+
+import styles from "./PageLoadingIndicator.module.scss";
+
+const PageLoadingIndicator: React.FC = () => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const handleStart = () => {
+      setIsLoading(true);
+    };
+
+    const handleComplete = () => {
+      setIsLoading(false);
+    };
+
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleComplete);
+    router.events.on("routeChangeError", handleComplete);
+
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleComplete);
+      router.events.off("routeChangeError", handleComplete);
+    };
+  }, [router.events]);
+
+  if (!isLoading) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.pageLoadingOverlay}
+      data-testid="page-loading-indicator"
+    >
+      <Spin size="large" tip="Loading..." />
+    </div>
+  );
+};
+
+export default PageLoadingIndicator;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -84,7 +84,7 @@ function WrappedApp({
 
         const shouldForceRefresh = buildDateGreaterThan(
           meta?.buildDate,
-          +currentVersionDate ?? 0
+          +(currentVersionDate ?? "0")
         );
         if (shouldForceRefresh) {
           refreshCacheAndReload();
@@ -93,7 +93,7 @@ function WrappedApp({
         console.log("cache", {
           shouldForceRefresh: shouldForceRefresh,
           latestVersionDate: meta?.buildDate,
-          currentVersionDate: +currentVersionDate ?? 0,
+          currentVersionDate: +(currentVersionDate ?? "0"),
         });
       });
   }, []);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,6 +25,7 @@ import { getCookies } from "src/utils/generalUtility";
 import { createToken } from "src/network/api/userApi";
 import CustomSkelton from "@/components/common/customSkelton";
 import { logOut } from "@/components/common/headers/loggedInHeaderNavigation";
+import PageLoadingIndicator from "@/components/common/PageLoadingIndicator";
 import moment from "moment";
 
 type AppOwnProps = { meta: any; canonical_url: string; returnURL: string };
@@ -40,70 +41,63 @@ function WrappedApp({
     [_, setIsAuthenticated, isAuthenticatedRef] = useState(
       !!(getCookies() as any)?.loginToken
     );
-  
-    const buildDateGreaterThan = (latestDate, currentDate) => {
-      const momLatestDateTime = moment(latestDate);
-      const momCurrentDateTime = moment(currentDate);
-   
-      return !!(momLatestDateTime.isAfter(momCurrentDateTime));
-    };
- 
- 
-   const refreshCacheAndReload = () => {
-      for (const key in localStorage) {
-        if (key !== "auth_token") {
-          localStorage.removeItem(key);
-        }
-      }
-     
-      const cookies = document.cookie.split("; ");
-        for (let cookie of cookies) {
-          const eqPos = cookie.indexOf("=");
-          const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-          if (name !== "loginToken"){
-            document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
-          }
-        }
- 
- 
-        if (window?.caches) {
-          window.caches.keys().then((names) => {
-            for (const name of names) {
-              caches.delete(name);
-            }
-          });
-      }
-   
+
+  const buildDateGreaterThan = (latestDate, currentDate) => {
+    const momLatestDateTime = moment(latestDate);
+    const momCurrentDateTime = moment(currentDate);
+
+    return !!momLatestDateTime.isAfter(momCurrentDateTime);
   };
 
- 
- 
-  useEffect(()=>{
+  const refreshCacheAndReload = () => {
+    for (const key in localStorage) {
+      if (key !== "auth_token") {
+        localStorage.removeItem(key);
+      }
+    }
+
+    const cookies = document.cookie.split("; ");
+    for (let cookie of cookies) {
+      const eqPos = cookie.indexOf("=");
+      const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+      if (name !== "loginToken") {
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+      }
+    }
+
+    if (window?.caches) {
+      window.caches.keys().then((names) => {
+        for (const name of names) {
+          caches.delete(name);
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
     fetch("/meta.json")
-    .then((response) => response.json())
-    .then((meta) => {
-      console.log('meta ===>', meta);
+      .then((response) => response.json())
+      .then((meta) => {
+        console.log("meta ===>", meta);
         const latestVersionDate = meta?.buildDate;
         const currentVersionDate = localStorage.getItem("build_number");
-        
+
         const shouldForceRefresh = buildDateGreaterThan(
           meta?.buildDate,
           +currentVersionDate ?? 0
         );
-         if (shouldForceRefresh) {
+        if (shouldForceRefresh) {
           refreshCacheAndReload();
           localStorage.setItem("build_number", meta?.buildDate);
         }
-         console.log('cache',{
+        console.log("cache", {
           shouldForceRefresh: shouldForceRefresh,
           latestVersionDate: meta?.buildDate,
-          currentVersionDate: +currentVersionDate??0
-        })
-  
-    });
- 
-  },[])
- 
+          currentVersionDate: +currentVersionDate ?? 0,
+        });
+      });
+  }, []);
+
   useEffect(() => {
     const fetchToken = async () => {
       if (router?.asPath) {
@@ -168,6 +162,7 @@ function WrappedApp({
   return (
     <CookiesProvider>
       <Provider store={store}>
+        <PageLoadingIndicator />
         <ErrorBoundary>
           <HeadContentAndPermissionComponent
             componentName={Component.displayName || Component.name}


### PR DESCRIPTION
## Summary

- Add `PageLoadingIndicator` component that shows a loading overlay during page navigation
- Integrate into `_app.tsx` to provide visual feedback when navigating between pages
- Improves user experience by indicating page loading state, especially from hot topic section

## Changes

- **New component**: `src/components/common/PageLoadingIndicator/index.tsx`
  - Listens to Next.js router events (`routeChangeStart`, `routeChangeComplete`, `routeChangeError`)
  - Displays Ant Design Spin component with overlay during navigation
  
- **Styles**: `src/components/common/PageLoadingIndicator/PageLoadingIndicator.module.scss`
  - Full-screen overlay with semi-transparent white background
  - Centered loading spinner
  
- **Integration**: `src/pages/_app.tsx`
  - Import and render `PageLoadingIndicator` component

## Test plan

- [x] PageLoadingIndicator component renders correctly
- [x] Shows loading indicator when route change starts
- [x] Hides loading indicator when route change completes
- [x] Hides loading indicator on route change error
- [x] Properly registers and unregisters event listeners
- [ ] Manual testing: Navigate from hot topics to topic page and verify loading indicator appears

## Test Results

```
PASS src/components/common/PageLoadingIndicator/__test__/PageLoadingIndicator.test.tsx
  PageLoadingIndicator
    ✓ should not render when not loading
    ✓ should render loading indicator when route change starts
    ✓ should hide loading indicator when route change completes
    ✓ should hide loading indicator when route change errors
    ✓ should register and unregister event listeners

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

Closes #2142

🤖 Generated with [Claude Code](https://claude.com/claude-code)