### PR TITLE
fix: show green border for camps with no in-review changes (#1798)

### DIFF
--- a/src/components/ComponentPages/TopicDetails/CampStatementCard/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/CampStatementCard/index.tsx
@@ -211,7 +211,7 @@ const CampStatementCard = ({ loadingIndicator }) => {
               ? "!border-canGreen"
               : router?.query?.status == "objected"
               ? "!border-canRed"
-              : router?.query?.asof == "review"
+              : router?.query?.asof == "review" && campStatement?.[0]?.in_review_changes > 0
               ? "!border-canOrange"
               : router?.query?.asof == "bydate"
               ? "border-[#4786CB]"

--- a/src/components/ComponentPages/TopicDetails/PreviewStatementModal/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/PreviewStatementModal/index.tsx
@@ -49,7 +49,7 @@ const StatementPreviewModal = () => {
   }, [haveStatementPreview]);
 
   const getBorderColor = () => {
-    if (router?.query?.viewversion == "1" || router?.query?.asof == "review") {
+    if (router?.query?.viewversion == "1" || (router?.query?.asof == "review" && campStatement?.in_review_changes > 0)) {
       return "!border-canOrange";
     } else if (router?.query?.asof == "bydate") {
       return "border-[#4786CB]";


### PR DESCRIPTION
When "Include Review" filter is active, camps without actual in-review changes were incorrectly showing orange border. Now only camps with in_review_changes > 0 show orange; others correctly fall through to green.