### PR TITLE
feat: add 'Ignore AI agent scores' toggle to Topics Refine filter

### DIFF
--- a/src/components/ComponentPages/Home/TopicsList/index.tsx
+++ b/src/components/ComponentPages/Home/TopicsList/index.tsx
@@ -58,12 +58,14 @@ const TopicsList = () => {
     sortScoreViewTopic,
     is_camp_archive_checked,
     filterByScore,
+    excludeBots,
     allAlgorithms,
   } = useSelector((state: RootState) => ({
     canonizedTopics: state.homePage?.canonizedTopicsData,
     asofdate: state.filters?.filterObject?.asofdate,
     asof: state.filters?.filterObject?.asof,
     algorithm: state.filters?.filterObject?.algorithm,
+    excludeBots: state?.filters?.filterObject?.exclude_bots,
     nameSpaces: state.homePage?.nameSpaces,
     filterNameSpace: state?.filters?.filterObject?.nameSpace,
     userEmail: state?.auth?.loggedInUser?.email,
@@ -216,6 +218,7 @@ const TopicsList = () => {
       page: "browse",
       topic_tags: getIdsOfFilteredTags(value, allTags),
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     const response = await getCanonizedTopicsApi(reqBody);
     setTotalTopics(response);
@@ -368,6 +371,7 @@ const TopicsList = () => {
     pageSize,
     pageNumber,
     onlyMyTopicsCheck,
+    excludeBots,
     value,
   ]);
 

--- a/src/components/ComponentPages/RefineFilter/index.tsx
+++ b/src/components/ComponentPages/RefineFilter/index.tsx
@@ -8,6 +8,7 @@ import {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setOpenDrawer,
 } from "src/store/slices/campDetailSlice";
 import FilterWithTree from "../../common/topicsFilter/filterWithTree";
@@ -34,6 +35,7 @@ const RefineFilter = () => {
     dispatch(setAsOfValues(2));
     dispatch(setClearAlgoFromRefineFilter("blind_popularity"));
     dispatch(setClearScoreFromRefineFilter(0));
+    dispatch(setExcludeBotsFromRefineFilter(false));
   };
 
   return (

--- a/src/components/ComponentPages/TopicDetails/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/index.tsx
@@ -97,6 +97,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
     asof,
     asofdate,
     algorithm,
+    excludeBots,
     campRecord,
     tree,
     campExist,
@@ -113,6 +114,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
     asof: state?.filters?.filterObject?.asof,
     asofdate: state.filters?.filterObject?.asofdate,
     algorithm: state.filters?.filterObject?.algorithm,
+    excludeBots: state?.filters?.filterObject?.exclude_bots,
     campRecord: state?.topicDetails?.currentCampRecord,
     tree: state?.topicDetails?.tree && state?.topicDetails?.tree[0],
     campExist: state?.topicDetails?.tree && state?.topicDetails?.tree[1],
@@ -203,6 +205,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
           update_all: 1,
           fetch_topic_history: viewThisVersionCheck ? 1 : null,
           current_user: isUserAuthenticated ? userEmail : "",
+          exclude_bots: excludeBots ? 1 : 0,
         };
 
         const reqBody = {
@@ -245,6 +248,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
   }, [
     asofdate,
     algorithm,
+    excludeBots,
     +(router?.query?.camp[1]?.split("-")[0] ?? 1),
     router?.query?.camp[0]?.split("-")[0],
   ]);
@@ -367,6 +371,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
     let reqBody = {
@@ -416,6 +421,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
 
@@ -459,6 +465,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
 
@@ -659,6 +666,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
           update_all: 1,
           fetch_topic_history: viewThisVersionCheck ? 1 : null,
           current_user: isUserAuthenticated ? userEmail : "",
+          exclude_bots: excludeBots ? 1 : 0,
         };
 
         // Call the API

--- a/src/components/common/topicsFilter/filterWithTree.tsx
+++ b/src/components/common/topicsFilter/filterWithTree.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Row,
   Col,
+  Switch,
 } from "antd";
 import Image from "next/image";
 import { useDispatch, useSelector } from "react-redux";
@@ -24,6 +25,7 @@ import {
   setIsReviewCanonizedTopics,
   setViewThisVersion,
   setFilterCanonizedTopics,
+  setExcludeBotsFilter,
 } from "src/store/slices/filtersSlice";
 import K from "src/constants";
 import { getCanonizedAlgorithmsApi } from "src/network/api/homePageApi";
@@ -33,6 +35,7 @@ import {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setDisbaleApplyBtn,
 } from "src/store/slices/campDetailSlice";
 import SecondaryButton from "components/shared/Buttons/SecondaryButton";
@@ -105,6 +108,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     asOfValues,
     clearAlgoFromRefineFilter,
     clearScoreFromRefineFilter,
+    excludeBotsFromRefineFilter,
     disbaleApplyBtn,
     userEmail,
     algorithm,
@@ -127,6 +131,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     asOfValues: state.topicDetails.asOfValues,
     clearAlgoFromRefineFilter: state.topicDetails.clearAlgoFromRefineFilter,
     clearScoreFromRefineFilter: state.topicDetails.clearScoreFromRefineFilter,
+    excludeBotsFromRefineFilter: state.topicDetails.excludeBotsFromRefineFilter,
     disbaleApplyBtn: state.topicDetails.disbaleApplyBtn,
     userEmail: state?.auth?.loggedInUser?.email,
   }));
@@ -461,6 +466,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     // Step 2: Dispatch Redux actions and perform state updates
     dispatch(setOpenDrawer(false));
     filterOnScore(clearScoreFromRefineFilter);
+    dispatch(setExcludeBotsFilter(excludeBotsFromRefineFilter));
     await selectAlgorithm(clearAlgoFromRefineFilter);
     // Step 3: Handle different cases based on selectedValue
     if (selectedValue === 2) {
@@ -699,6 +705,22 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
                     }
                   }}
                 />
+                <div
+                  className="flex items-center justify-between lg:w-4/5 w-full mt-6"
+                  id="refine_filter_section_exclude_bots_wrap"
+                >
+                  <span className="text-sm text-canBlack font-medium">
+                    Ignore AI agent scores
+                  </span>
+                  <Switch
+                    id="exclude_bots_switch"
+                    checked={excludeBotsFromRefineFilter}
+                    disabled={loadingIndicator}
+                    onChange={(checked) =>
+                      dispatch(setExcludeBotsFromRefineFilter(checked))
+                    }
+                  />
+                </div>
               </div>
             </Col>
             <Col xs={24} className="" id="refine_filter_section_as_of_col">

--- a/src/network/api/campDetailApi.ts
+++ b/src/network/api/campDetailApi.ts
@@ -22,9 +22,13 @@ export const getTreesApi = async (reqBody, loginToken = null) => {
       TreeRequest.getTrees(reqBody, loginToken),
       false
     );
-    store.dispatch(setTree(trees?.data || []));
+    // Guard against an error envelope (HTTP 200 body with a non-200 code, e.g. a scoring
+    // exception). Dispatching its malformed shape would crash the tree renderer, so treat it
+    // as "no tree" instead of white-screening.
+    const isErrorEnvelope = trees?.code && trees.code !== 200;
+    store.dispatch(setTree(isErrorEnvelope ? [] : trees?.data || []));
     return {
-      treeData: trees?.data?.at(0),
+      treeData: isErrorEnvelope ? {} : trees?.data?.at(0),
       status_code: trees?.code,
       message: trees?.message || "",
     };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -58,7 +58,26 @@ const rootReducer = (state, action) => {
   if (action.type === "auth/setLogout") {
     state.filters = undefined;
   }
-  return combinedReducer(state, action);
+  const nextState = combinedReducer(state, action);
+  // The bot-exclusion toggle must never be restored from storage — it defaults OFF on every
+  // load so a refresh always recovers the UI even if a request for that variant misbehaves.
+  if (action.type === REHYDRATE) {
+    return {
+      ...nextState,
+      filters: {
+        ...nextState.filters,
+        filterObject: {
+          ...nextState.filters?.filterObject,
+          exclude_bots: 0,
+        },
+      },
+      topicDetails: {
+        ...nextState.topicDetails,
+        excludeBotsFromRefineFilter: false,
+      },
+    };
+  }
+  return nextState;
 };
 
 const persistConfig = {

--- a/src/store/slices/campDetailSlice.ts
+++ b/src/store/slices/campDetailSlice.ts
@@ -33,6 +33,7 @@ export const treeSlice = createSlice({
     asOfValues: 0,
     clearAlgoFromRefineFilter: "",
     clearScoreFromRefineFilter: 0,
+    excludeBotsFromRefineFilter: false,
     // openConsensusTreePopup: true,
     manageSupportUrlLink: null,
     CurrentCheckSupportStatus: null,
@@ -167,6 +168,9 @@ export const treeSlice = createSlice({
     setClearScoreFromRefineFilter: (state, action) => {
       state.clearScoreFromRefineFilter = action.payload;
     },
+    setExcludeBotsFromRefineFilter: (state, action) => {
+      state.excludeBotsFromRefineFilter = action.payload;
+    },
     setGlobalUserProfileData: (state, action) => {
       state.globalUserProfileData = action.payload;
     },
@@ -260,6 +264,7 @@ export const {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setGlobalUserProfileData,
   setGlobalUserProfileDataEmail,
   setOpenDrawerForDirectSupportedCamp,

--- a/src/store/slices/filtersSlice.ts
+++ b/src/store/slices/filtersSlice.ts
@@ -15,6 +15,7 @@ export const filtersSlice = createSlice({
       search: "",
       includeReview: false,
       is_archive: 0,
+      exclude_bots: 0,
     },
     selectedCampNode: null,
     current_date: new Date().valueOf(),
@@ -47,6 +48,12 @@ export const filtersSlice = createSlice({
     },
     setViewThisVersion: (state, action) => {
       state.viewThisVersionCheck = action.payload;
+    },
+    setExcludeBotsFilter: (state, action) => {
+      state.filterObject = {
+        ...state.filterObject,
+        exclude_bots: action.payload ? 1 : 0,
+      };
     },
     setCurrentDate: (state, action) => {
       state.current_date = action.payload;
@@ -84,6 +91,7 @@ export const {
   setIsReviewCanonizedTopics,
   setCurrentCamp,
   setViewThisVersion,
+  setExcludeBotsFilter,
   setCurrentDate,
   setShowDrawer,
   setCampWithScorevalue,


### PR DESCRIPTION
Adds a toggle in the Topic-page Refine drawer (and browse list) that requests human-only scores with bot (AI agent) support excluded.

- campDetailSlice: drawer-local pending state excludeBotsFromRefineFilter
- filtersSlice: exclude_bots applied-filter state + setExcludeBotsFilter
- filterWithTree: Switch UI + apply wiring; reset on Clear all
- thread exclude_bots into getTreesApi bodies and the browse reqBody
- store: never restore exclude_bots from persistence (defaults off each load)
- getTreesApi: render empty instead of white-screening on an error envelope