### PR TITLE
feat: default 'Ignore AI agent scores' Refine toggle to ON

### DIFF
--- a/src/components/ComponentPages/RefineFilter/index.tsx
+++ b/src/components/ComponentPages/RefineFilter/index.tsx
@@ -35,7 +35,7 @@ const RefineFilter = () => {
     dispatch(setAsOfValues(2));
     dispatch(setClearAlgoFromRefineFilter("blind_popularity"));
     dispatch(setClearScoreFromRefineFilter(0));
-    dispatch(setExcludeBotsFromRefineFilter(false));
+    dispatch(setExcludeBotsFromRefineFilter(true));
   };
 
   return (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,8 +59,9 @@ const rootReducer = (state, action) => {
     state.filters = undefined;
   }
   const nextState = combinedReducer(state, action);
-  // The bot-exclusion toggle must never be restored from storage — it defaults OFF on every
-  // load so a refresh always recovers the UI even if a request for that variant misbehaves.
+  // The bot-exclusion toggle must never be restored from storage — it defaults ON on every
+  // load so a refresh always lands on the canonical "ignore AI agent scores" view regardless
+  // of whatever value was persisted in a prior session.
   if (action.type === REHYDRATE) {
     return {
       ...nextState,
@@ -68,12 +69,12 @@ const rootReducer = (state, action) => {
         ...nextState.filters,
         filterObject: {
           ...nextState.filters?.filterObject,
-          exclude_bots: 0,
+          exclude_bots: 1,
         },
       },
       topicDetails: {
         ...nextState.topicDetails,
-        excludeBotsFromRefineFilter: false,
+        excludeBotsFromRefineFilter: true,
       },
     };
   }

--- a/src/store/slices/campDetailSlice.ts
+++ b/src/store/slices/campDetailSlice.ts
@@ -33,7 +33,7 @@ export const treeSlice = createSlice({
     asOfValues: 0,
     clearAlgoFromRefineFilter: "",
     clearScoreFromRefineFilter: 0,
-    excludeBotsFromRefineFilter: false,
+    excludeBotsFromRefineFilter: true,
     // openConsensusTreePopup: true,
     manageSupportUrlLink: null,
     CurrentCheckSupportStatus: null,

--- a/src/store/slices/filtersSlice.ts
+++ b/src/store/slices/filtersSlice.ts
@@ -15,7 +15,7 @@ export const filtersSlice = createSlice({
       search: "",
       includeReview: false,
       is_archive: 0,
-      exclude_bots: 0,
+      exclude_bots: 1,
     },
     selectedCampNode: null,
     current_date: new Date().valueOf(),


### PR DESCRIPTION
Flip the bot-exclusion default from OFF to ON across initial state, the REHYDRATE override (so a persisted OFF value is ignored on reload), and the Refine 'Clear all' reset.