### PR TITLE
Add 'Ignore AI agent scores' toggle to Topics Refine filter

### DIFF
--- a/src/components/ComponentPages/Home/TopicsList/index.tsx
+++ b/src/components/ComponentPages/Home/TopicsList/index.tsx
@@ -58,12 +58,14 @@ const TopicsList = () => {
     sortScoreViewTopic,
     is_camp_archive_checked,
     filterByScore,
+    excludeBots,
     allAlgorithms,
   } = useSelector((state: RootState) => ({
     canonizedTopics: state.homePage?.canonizedTopicsData,
     asofdate: state.filters?.filterObject?.asofdate,
     asof: state.filters?.filterObject?.asof,
     algorithm: state.filters?.filterObject?.algorithm,
+    excludeBots: state?.filters?.filterObject?.exclude_bots,
     nameSpaces: state.homePage?.nameSpaces,
     filterNameSpace: state?.filters?.filterObject?.nameSpace,
     userEmail: state?.auth?.loggedInUser?.email,
@@ -216,6 +218,7 @@ const TopicsList = () => {
       page: "browse",
       topic_tags: getIdsOfFilteredTags(value, allTags),
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     const response = await getCanonizedTopicsApi(reqBody);
     setTotalTopics(response);
@@ -368,6 +371,7 @@ const TopicsList = () => {
     pageSize,
     pageNumber,
     onlyMyTopicsCheck,
+    excludeBots,
     value,
   ]);
 

--- a/src/components/ComponentPages/RefineFilter/index.tsx
+++ b/src/components/ComponentPages/RefineFilter/index.tsx
@@ -35,7 +35,7 @@ const RefineFilter = () => {
     dispatch(setAsOfValues(2));
     dispatch(setClearAlgoFromRefineFilter("blind_popularity"));
     dispatch(setClearScoreFromRefineFilter(0));
-    dispatch(setExcludeBotsFromRefineFilter(false));
+    dispatch(setExcludeBotsFromRefineFilter(true));
   };
 
   return (

--- a/src/components/ComponentPages/RefineFilter/index.tsx
+++ b/src/components/ComponentPages/RefineFilter/index.tsx
@@ -8,6 +8,7 @@ import {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setOpenDrawer,
 } from "src/store/slices/campDetailSlice";
 import FilterWithTree from "../../common/topicsFilter/filterWithTree";
@@ -34,6 +35,7 @@ const RefineFilter = () => {
     dispatch(setAsOfValues(2));
     dispatch(setClearAlgoFromRefineFilter("blind_popularity"));
     dispatch(setClearScoreFromRefineFilter(0));
+    dispatch(setExcludeBotsFromRefineFilter(false));
   };
 
   return (

--- a/src/components/ComponentPages/TopicDetails/index.tsx
+++ b/src/components/ComponentPages/TopicDetails/index.tsx
@@ -97,6 +97,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
     asof,
     asofdate,
     algorithm,
+    excludeBots,
     campRecord,
     tree,
     campExist,
@@ -113,6 +114,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
     asof: state?.filters?.filterObject?.asof,
     asofdate: state.filters?.filterObject?.asofdate,
     algorithm: state.filters?.filterObject?.algorithm,
+    excludeBots: state?.filters?.filterObject?.exclude_bots,
     campRecord: state?.topicDetails?.currentCampRecord,
     tree: state?.topicDetails?.tree && state?.topicDetails?.tree[0],
     campExist: state?.topicDetails?.tree && state?.topicDetails?.tree[1],
@@ -203,6 +205,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
           update_all: 1,
           fetch_topic_history: viewThisVersionCheck ? 1 : null,
           current_user: isUserAuthenticated ? userEmail : "",
+          exclude_bots: excludeBots ? 1 : 0,
         };
 
         const reqBody = {
@@ -245,6 +248,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
   }, [
     asofdate,
     algorithm,
+    excludeBots,
     +(router?.query?.camp[1]?.split("-")[0] ?? 1),
     router?.query?.camp[0]?.split("-")[0],
   ]);
@@ -367,6 +371,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
     let reqBody = {
@@ -416,6 +421,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
 
@@ -459,6 +465,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
       update_all: 1,
       fetch_topic_history: +router?.query?.topic_history,
       current_user: isUserAuthenticated ? userEmail : "",
+      exclude_bots: excludeBots ? 1 : 0,
     };
     setRemoveSupportSpinner(true);
 
@@ -659,6 +666,7 @@ const TopicDetails = ({ serverSideCall }: any) => {
           update_all: 1,
           fetch_topic_history: viewThisVersionCheck ? 1 : null,
           current_user: isUserAuthenticated ? userEmail : "",
+          exclude_bots: excludeBots ? 1 : 0,
         };
 
         // Call the API

--- a/src/components/common/topicsFilter/filterWithTree.tsx
+++ b/src/components/common/topicsFilter/filterWithTree.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Row,
   Col,
+  Switch,
 } from "antd";
 import Image from "next/image";
 import { useDispatch, useSelector } from "react-redux";
@@ -24,6 +25,7 @@ import {
   setIsReviewCanonizedTopics,
   setViewThisVersion,
   setFilterCanonizedTopics,
+  setExcludeBotsFilter,
 } from "src/store/slices/filtersSlice";
 import K from "src/constants";
 import { getCanonizedAlgorithmsApi } from "src/network/api/homePageApi";
@@ -33,6 +35,7 @@ import {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setDisbaleApplyBtn,
 } from "src/store/slices/campDetailSlice";
 import SecondaryButton from "components/shared/Buttons/SecondaryButton";
@@ -105,6 +108,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     asOfValues,
     clearAlgoFromRefineFilter,
     clearScoreFromRefineFilter,
+    excludeBotsFromRefineFilter,
     disbaleApplyBtn,
     userEmail,
     algorithm,
@@ -127,6 +131,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     asOfValues: state.topicDetails.asOfValues,
     clearAlgoFromRefineFilter: state.topicDetails.clearAlgoFromRefineFilter,
     clearScoreFromRefineFilter: state.topicDetails.clearScoreFromRefineFilter,
+    excludeBotsFromRefineFilter: state.topicDetails.excludeBotsFromRefineFilter,
     disbaleApplyBtn: state.topicDetails.disbaleApplyBtn,
     userEmail: state?.auth?.loggedInUser?.email,
   }));
@@ -461,6 +466,7 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
     // Step 2: Dispatch Redux actions and perform state updates
     dispatch(setOpenDrawer(false));
     filterOnScore(clearScoreFromRefineFilter);
+    dispatch(setExcludeBotsFilter(excludeBotsFromRefineFilter));
     await selectAlgorithm(clearAlgoFromRefineFilter);
     // Step 3: Handle different cases based on selectedValue
     if (selectedValue === 2) {
@@ -699,6 +705,22 @@ const FilterWithTree = ({ loadingIndicator }: any) => {
                     }
                   }}
                 />
+                <div
+                  className="flex items-center justify-between lg:w-4/5 w-full mt-6"
+                  id="refine_filter_section_exclude_bots_wrap"
+                >
+                  <span className="text-sm text-canBlack font-medium">
+                    Ignore AI agent scores
+                  </span>
+                  <Switch
+                    id="exclude_bots_switch"
+                    checked={excludeBotsFromRefineFilter}
+                    disabled={loadingIndicator}
+                    onChange={(checked) =>
+                      dispatch(setExcludeBotsFromRefineFilter(checked))
+                    }
+                  />
+                </div>
               </div>
             </Col>
             <Col xs={24} className="" id="refine_filter_section_as_of_col">

--- a/src/network/api/campDetailApi.ts
+++ b/src/network/api/campDetailApi.ts
@@ -22,9 +22,13 @@ export const getTreesApi = async (reqBody, loginToken = null) => {
       TreeRequest.getTrees(reqBody, loginToken),
       false
     );
-    store.dispatch(setTree(trees?.data || []));
+    // Guard against an error envelope (HTTP 200 body with a non-200 code, e.g. a scoring
+    // exception). Dispatching its malformed shape would crash the tree renderer, so treat it
+    // as "no tree" instead of white-screening.
+    const isErrorEnvelope = trees?.code && trees.code !== 200;
+    store.dispatch(setTree(isErrorEnvelope ? [] : trees?.data || []));
     return {
-      treeData: trees?.data?.at(0),
+      treeData: isErrorEnvelope ? {} : trees?.data?.at(0),
       status_code: trees?.code,
       message: trees?.message || "",
     };

--- a/src/pages/topic/[...camp].tsx
+++ b/src/pages/topic/[...camp].tsx
@@ -166,6 +166,11 @@ export async function getServerSideProps({ req, query, res }) {
     fetch_topic_history: query?.viewversion == "1" ? 1 : null,
     view: req.cookies[cookieKey] ? req.cookies[cookieKey] : hashValue,
     current_user: userEmail,
+    // Match the client default: the "Ignore AI agent scores" toggle always rehydrates ON,
+    // and the client skips the on-mount refetch for SSR data (serverSideCall guard), so the
+    // server-rendered scores must exclude bots too — otherwise a refresh shows bot-included
+    // scores while the toggle reads ON. Respect ?exclude_bots=0 if ever added to the URL.
+    exclude_bots: query?.exclude_bots === "0" ? 0 : 1,
   };
   const reqBody = {
     topic_num: topicNum,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -58,7 +58,26 @@ const rootReducer = (state, action) => {
   if (action.type === "auth/setLogout") {
     state.filters = undefined;
   }
-  return combinedReducer(state, action);
+  const nextState = combinedReducer(state, action);
+  // The bot-exclusion toggle must never be restored from storage — it defaults OFF on every
+  // load so a refresh always recovers the UI even if a request for that variant misbehaves.
+  if (action.type === REHYDRATE) {
+    return {
+      ...nextState,
+      filters: {
+        ...nextState.filters,
+        filterObject: {
+          ...nextState.filters?.filterObject,
+          exclude_bots: 0,
+        },
+      },
+      topicDetails: {
+        ...nextState.topicDetails,
+        excludeBotsFromRefineFilter: false,
+      },
+    };
+  }
+  return nextState;
 };
 
 const persistConfig = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,8 +59,9 @@ const rootReducer = (state, action) => {
     state.filters = undefined;
   }
   const nextState = combinedReducer(state, action);
-  // The bot-exclusion toggle must never be restored from storage — it defaults OFF on every
-  // load so a refresh always recovers the UI even if a request for that variant misbehaves.
+  // The bot-exclusion toggle must never be restored from storage — it defaults ON on every
+  // load so a refresh always lands on the canonical "ignore AI agent scores" view regardless
+  // of whatever value was persisted in a prior session.
   if (action.type === REHYDRATE) {
     return {
       ...nextState,
@@ -68,12 +69,12 @@ const rootReducer = (state, action) => {
         ...nextState.filters,
         filterObject: {
           ...nextState.filters?.filterObject,
-          exclude_bots: 0,
+          exclude_bots: 1,
         },
       },
       topicDetails: {
         ...nextState.topicDetails,
-        excludeBotsFromRefineFilter: false,
+        excludeBotsFromRefineFilter: true,
       },
     };
   }

--- a/src/store/slices/campDetailSlice.ts
+++ b/src/store/slices/campDetailSlice.ts
@@ -33,7 +33,7 @@ export const treeSlice = createSlice({
     asOfValues: 0,
     clearAlgoFromRefineFilter: "",
     clearScoreFromRefineFilter: 0,
-    excludeBotsFromRefineFilter: false,
+    excludeBotsFromRefineFilter: true,
     // openConsensusTreePopup: true,
     manageSupportUrlLink: null,
     CurrentCheckSupportStatus: null,

--- a/src/store/slices/campDetailSlice.ts
+++ b/src/store/slices/campDetailSlice.ts
@@ -33,6 +33,7 @@ export const treeSlice = createSlice({
     asOfValues: 0,
     clearAlgoFromRefineFilter: "",
     clearScoreFromRefineFilter: 0,
+    excludeBotsFromRefineFilter: false,
     // openConsensusTreePopup: true,
     manageSupportUrlLink: null,
     CurrentCheckSupportStatus: null,
@@ -167,6 +168,9 @@ export const treeSlice = createSlice({
     setClearScoreFromRefineFilter: (state, action) => {
       state.clearScoreFromRefineFilter = action.payload;
     },
+    setExcludeBotsFromRefineFilter: (state, action) => {
+      state.excludeBotsFromRefineFilter = action.payload;
+    },
     setGlobalUserProfileData: (state, action) => {
       state.globalUserProfileData = action.payload;
     },
@@ -260,6 +264,7 @@ export const {
   setAsOfValues,
   setClearAlgoFromRefineFilter,
   setClearScoreFromRefineFilter,
+  setExcludeBotsFromRefineFilter,
   setGlobalUserProfileData,
   setGlobalUserProfileDataEmail,
   setOpenDrawerForDirectSupportedCamp,

--- a/src/store/slices/filtersSlice.ts
+++ b/src/store/slices/filtersSlice.ts
@@ -15,6 +15,7 @@ export const filtersSlice = createSlice({
       search: "",
       includeReview: false,
       is_archive: 0,
+      exclude_bots: 0,
     },
     selectedCampNode: null,
     current_date: new Date().valueOf(),
@@ -47,6 +48,12 @@ export const filtersSlice = createSlice({
     },
     setViewThisVersion: (state, action) => {
       state.viewThisVersionCheck = action.payload;
+    },
+    setExcludeBotsFilter: (state, action) => {
+      state.filterObject = {
+        ...state.filterObject,
+        exclude_bots: action.payload ? 1 : 0,
+      };
     },
     setCurrentDate: (state, action) => {
       state.current_date = action.payload;
@@ -84,6 +91,7 @@ export const {
   setIsReviewCanonizedTopics,
   setCurrentCamp,
   setViewThisVersion,
+  setExcludeBotsFilter,
   setCurrentDate,
   setShowDrawer,
   setCampWithScorevalue,

--- a/src/store/slices/filtersSlice.ts
+++ b/src/store/slices/filtersSlice.ts
@@ -15,7 +15,7 @@ export const filtersSlice = createSlice({
       search: "",
       includeReview: false,
       is_archive: 0,
-      exclude_bots: 0,
+      exclude_bots: 1,
     },
     selectedCampNode: null,
     current_date: new Date().valueOf(),


### PR DESCRIPTION
This pull request introduces a new "Ignore AI agent scores" (exclude bots) toggle to the topic and camp filtering system, defaulting to ON for all users and ensuring consistent behavior across client and server renders. The toggle is integrated into the Redux state, the filter UI, and all relevant API requests. Additional safeguards ensure the toggle state is not restored from persisted storage and always defaults to ON on page load.

**New "Ignore AI agent scores" (exclude bots) toggle:**

- Added `exclude_bots` to the Redux filter state, defaulting to `1` (ON), and ensured it is always set to ON when rehydrating state from storage (`src/store/slices/filtersSlice.ts`, `src/store/index.ts`) [[1]](diffhunk://#diff-36fc45458ddf421818fbb7cdd34bbaf10260687c34bd403579cb487648a17e65R18) [[2]](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL61-R81).
- Added Redux actions and reducers for updating the `exclude_bots` filter and the related refine filter state (`src/store/slices/filtersSlice.ts`, `src/store/slices/campDetailSlice.ts`) [[1]](diffhunk://#diff-36fc45458ddf421818fbb7cdd34bbaf10260687c34bd403579cb487648a17e65R52-R57) [[2]](diffhunk://#diff-36fc45458ddf421818fbb7cdd34bbaf10260687c34bd403579cb487648a17e65R94) [[3]](diffhunk://#diff-8445bcbaa23953159817cd377c326dd008761170b02307cfd6b36e27d322825eR36) [[4]](diffhunk://#diff-8445bcbaa23953159817cd377c326dd008761170b02307cfd6b36e27d322825eR171-R173) [[5]](diffhunk://#diff-8445bcbaa23953159817cd377c326dd008761170b02307cfd6b36e27d322825eR267).
- Integrated the toggle into the filter UI as a Switch labeled "Ignore AI agent scores" in the Refine Filter panel (`src/components/common/topicsFilter/filterWithTree.tsx`).
- Ensured the toggle is included in all relevant API requests and selectors in the Topics List and Topic Details components (`src/components/ComponentPages/Home/TopicsList/index.tsx`, `src/components/ComponentPages/TopicDetails/index.tsx`) [[1]](diffhunk://#diff-f40ab2c6aa010306999112c48400cf4e53f5969460442b16cde42c676a1aea28R61-R68) [[2]](diffhunk://#diff-f40ab2c6aa010306999112c48400cf4e53f5969460442b16cde42c676a1aea28R221) [[3]](diffhunk://#diff-f40ab2c6aa010306999112c48400cf4e53f5969460442b16cde42c676a1aea28R374) [[4]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR100) [[5]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR117) [[6]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR208) [[7]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR251) [[8]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR374) [[9]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR424) [[10]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR468) [[11]](diffhunk://#diff-93a4369dc6d3e720bdbc4cedb9d093fda0d8083f8d869d299a1c8c6e5def5f5aR669).

**Consistent server-side and client-side rendering:**

- Updated server-side data fetching to default to excluding bot scores unless explicitly overridden by the URL (`src/pages/topic/[...camp].tsx`) ([src/pages/topic/[...camp].tsxR169-R173](diffhunk://#diff-91d734285949d6c1729e70cd724dd46d1030daf0af99419d27adf4a85eabd830R169-R173)).
- Ensured the toggle is always ON after a page refresh, regardless of any previously persisted state (`src/store/index.ts`).

**UI and state management enhancements:**

- Added actions to synchronize the refine filter state and main filter state for the exclude bots toggle, ensuring the UI and API requests stay in sync (`src/components/ComponentPages/RefineFilter/index.tsx`, `src/components/common/topicsFilter/filterWithTree.tsx`) [[1]](diffhunk://#diff-b46c0f9e26f37f6dc190ab3a9f77e9b82f3cc82fe48f0a6f470c23c492007335R11) [[2]](diffhunk://#diff-b46c0f9e26f37f6dc190ab3a9f77e9b82f3cc82fe48f0a6f470c23c492007335R38) [[3]](diffhunk://#diff-4c5520d3984092f8998931f341cb945ff169755334bc2c6a055a26d47991122cR28) [[4]](diffhunk://#diff-4c5520d3984092f8998931f341cb945ff169755334bc2c6a055a26d47991122cR38) [[5]](diffhunk://#diff-4c5520d3984092f8998931f341cb945ff169755334bc2c6a055a26d47991122cR111) [[6]](diffhunk://#diff-4c5520d3984092f8998931f341cb945ff169755334bc2c6a055a26d47991122cR134) [[7]](diffhunk://#diff-4c5520d3984092f8998931f341cb945ff169755334bc2c6a055a26d47991122cR469).

**Error handling improvement:**

- Improved error handling for API responses in tree fetching to avoid crashes if a scoring exception occurs (`src/network/api/campDetailApi.ts`).

This update ensures that users see human-only scores by default and that toggling the "Ignore AI agent scores" option is reflected everywhere, providing a more consistent and predictable user experience.