### PR TITLE
Fix: add missing .editorContent h1 rule so display view matches editor

### DIFF
--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -813,6 +813,10 @@ body {
 }
 
 .editorContent {
+  h1 {
+    @apply text-4xl;
+  }
+
   h2 {
     @apply text-3xl;
   }


### PR DESCRIPTION
Display view (CampStatementCard) styles headings via .editorContent rules, but had no h1 rule, so <h1> fell back to Tailwind preflight (font-size:inherit) and rendered small — while the CKEditor 5 edit view injects its own .ck-content h1 style. Add h1 { @apply text-4xl; } to align display with the editor.